### PR TITLE
Fix Parameters

### DIFF
--- a/MiBand-Heartrate-2/Extras/DeviceHeartrateOscOutput.cs
+++ b/MiBand-Heartrate-2/Extras/DeviceHeartrateOscOutput.cs
@@ -23,11 +23,19 @@ namespace MiBand_Heartrate_2.Extras
             /// Heart rate par min [0, 255]
             /// </summary>
             public static readonly string HeartRateInt = $"{ParametersAddress}/HeartRateInt";
+            public static readonly string HeartRate3 = $"{ParametersAddress}/HeartRate3";
+
+            /// <summary>
+            /// Normalized Heart rate ([0, 255] -> [-1, 1])
+            /// </summary>
+            public static readonly string HeartRateFloat = $"{ParametersAddress}/HeartRateFloat";
+            public static readonly string HeartRate = $"{ParametersAddress}/HeartRate";
 
             /// <summary>
             /// Normalized Heart rate ([0, 255] -> [0, 1])
             /// </summary>
-            public static readonly string HeartRateFloat = $"{ParametersAddress}/HeartRateFloat";
+            public static readonly string HeartRateFloat01 = $"{ParametersAddress}/HeartRateFloat01";
+            public static readonly string HeartRate2 = $"{ParametersAddress}/HeartRate2";
 
             /// <summary>
             /// 1 : QRS Interval (Temporarily set it to 1/5 of the RR interval)
@@ -103,8 +111,18 @@ namespace MiBand_Heartrate_2.Extras
 
         private void OnChangeHeartrate()
         {
-            _oscSender.Send(new OscMessage(Addresses.HeartRateInt, (int)_device.Heartrate));
-            _oscSender.Send(new OscMessage(Addresses.HeartRateFloat, _device.Heartrate / 255f));
+            var heartRateInt = (int)_device.Heartrate;
+            var heartRateFloat = _device.Heartrate / 127f - 1f;
+            var heartRateFloat01 = _device.Heartrate / 255;
+            
+            _oscSender.Send(new OscMessage(Addresses.HeartRateInt, heartRateInt));
+            _oscSender.Send(new OscMessage(Addresses.HeartRate3, heartRateInt));
+            
+            _oscSender.Send(new OscMessage(Addresses.HeartRateFloat, heartRateFloat));
+            _oscSender.Send(new OscMessage(Addresses.HeartRate, heartRateFloat));
+            
+            _oscSender.Send(new OscMessage(Addresses.HeartRateFloat01, heartRateFloat01));
+            _oscSender.Send(new OscMessage(Addresses.HeartRate2, heartRateFloat01));
         }
 
         private void OnHeartrateMonitorStarted()

--- a/README.ja.md
+++ b/README.ja.md
@@ -80,7 +80,11 @@ Windows10でMi Bandデバイスで心拍数を取得します。
 |Addresss|Value Type|Description|
 |-|-|-|
 |/avatar/parameters/HeartRateInt|Int|心拍数（毎分） [0, 255]|
-|/avatar/parameters/HeartRateFloat|Float|正規化された心拍数（毎分） ([0, 255] -> [0, 1]) <br> これはラジアルを使用したシェイプキーの操作をするときに有効です。[参考リンク](https://note.com/citron_vr/n/n7d54ebaebd83)|
+|/avatar/parameters/HeartRate3|Int|HeartRateIntと同じ|
+|/avatar/parameters/HeartRateFloat|Float|正規化された心拍数（毎分） ([0, 255] -> [-1, 1])|
+|/avatar/parameters/HeartRate|Float|HeartRateFloatと同じ|
+|/avatar/parameters/HeartRateFloat01|Float|正規化された心拍数（毎分） ([0, 255] -> [0, 1]) <br> これはラジアルを使用したシェイプキーの操作をするときに有効です。[参考リンク](https://note.com/citron_vr/n/n7d54ebaebd83)|
+|/avatar/parameters/HeartRate2|Float|HeartRateFloat01と同じ|
 |/avatar/parameters/HeartBeatInt|Int|1 : QRS時間（ドックンの時間）(心拍の1/5の時間としています) <br> 0 : それ以外の時間|
 |/avatar/parameters/HeartBeatPulse|Bool|True : QRS時間（ドックンの時間）(心拍の1/5の時間としています) <br> False : それ以外の時間|
 er timesarameters/HeartBeatToggle|Bool|心拍ごとに値が反転します|
@@ -108,7 +112,12 @@ er timesarameters/HeartBeatToggle|Bool|心拍ごとに値が反転します|
 * [Mi Band 2 Authentication by leojrfs](https://leojrfs.github.io/writing/miband2-part1-auth/#reference), [python](https://github.com/leojrfs/miband2)
 * https://github.com/creotiv/MiBand2
 * [How I hacked my Xiaomi MiBand 2 fitness tracker — a step-by-step Linux guide by Andrey Nikishaev](https://medium.com/machine-learning-world/how-i-hacked-xiaomi-miband-2-to-control-it-from-linux-a5bd2f36d3ad)
+
+VRChat
+* [vard88508/vrc-osc-miband-hrm: Mi Band/Amazfit heart rate monitor with OSC integration for VRChat](https://github.com/vard88508/vrc-osc-miband-hrm)
 * [ラジアルでのシェイプキー操作方法｜みかんねここ｜note](https://note.com/citron_vr/n/n7d54ebaebd83)
+* [OSC HeartRateSendersドキュメントページ - おめが？日記_(2)](https://omega.hatenadiary.jp/entry/2022/02/27/035024)
+* [【Mi スマートバンド(Mi Band) × VRChat OSC】自分の心拍数をアバターに表示する方法！ | Till0196のぼーびろく](https://till0196.com/post16907)
 
 
 ### Thirdparty licenses

--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ If "Send OSC to VRChat" is enabled, this app will continue to send the following
 |Addresss|Value Type|Description|
 |-|-|-|
 |/avatar/parameters/HeartRateInt|Int|Heart rate par min [0, 255]|
-|/avatar/parameters/HeartRateFloat|Float|Normalized Heart rate ([0, 255] -> [0, 1]) <br> This is useful when controlling shape keys with Radial.|
+|/avatar/parameters/HeartRate3|Int|Same as HeartRateInt|
+|/avatar/parameters/HeartRateFloat|Float|Normalized Heart rate ([0, 255] -> [-1, 1])|
+|/avatar/parameters/HeartRate|Float|Same as HeartRateFloat|
+|/avatar/parameters/HeartRateFloat01|Float|Normalized Heart rate ([0, 255] -> [0, 1]) <br> This is useful when controlling shape keys with Radial.|
+|/avatar/parameters/HeartRate2|Float|Same as HeartRateFloat01|
 |/avatar/parameters/HeartBeatInt|Int|1 : QRS Interval (Temporarily set it to 1/5 of the RR interval) <br> 0 : Other times|
 |/avatar/parameters/HeartBeatPulse|Bool|True : QRS Interval (Temporarily set it to 1/5 of the RR interval) <br> False : Other times|
 |/avatar/parameters/HeartBeatToggle|Bool|Reverses with each heartbeat|
@@ -98,6 +102,12 @@ If "Send OSC to VRChat" is enabled, this app will continue to send the following
 * [Mi Band 2 Authentication by leojrfs](https://leojrfs.github.io/writing/miband2-part1-auth/#reference), [python](https://github.com/leojrfs/miband2)
 * https://github.com/creotiv/MiBand2
 * [How I hacked my Xiaomi MiBand 2 fitness tracker — a step-by-step Linux guide by Andrey Nikishaev](https://medium.com/machine-learning-world/how-i-hacked-xiaomi-miband-2-to-control-it-from-linux-a5bd2f36d3ad)
+
+VRChat
+* [vard88508/vrc-osc-miband-hrm: Mi Band/Amazfit heart rate monitor with OSC integration for VRChat](https://github.com/vard88508/vrc-osc-miband-hrm)
+* [ラジアルでのシェイプキー操作方法｜みかんねここ｜note](https://note.com/citron_vr/n/n7d54ebaebd83)
+* [OSC HeartRateSendersドキュメントページ - おめが？日記_(2)](https://omega.hatenadiary.jp/entry/2022/02/27/035024)
+* [【Mi スマートバンド(Mi Band) × VRChat OSC】自分の心拍数をアバターに表示する方法！ | Till0196のぼーびろく](https://till0196.com/post16907)
 
 
 ### Thirdparty licenses


### PR DESCRIPTION
# Overview
Parameters renamed for compatibility with other tools.
* [vard88508/vrc-osc-miband-hrm: Mi Band/Amazfit heart rate monitor with OSC integration for VRChat](https://github.com/vard88508/vrc-osc-miband-hrm)
* [OSC HeartRateSendersドキュメントページ - おめが？日記_(2)](https://omega.hatenadiary.jp/entry/2022/02/27/035024)

# Please note that the behavior of `HeartRateFloat` has changed.

# Changes
## Before
|Addresss|Value Type|Description|
|-|-|-|
|/avatar/parameters/HeartRateInt|Int|Heart rate par min [0, 255]|
|/avatar/parameters/HeartRateFloat|Float|Normalized Heart rate ([0, 255] -> [0, 1]) <br> This is useful when controlling shape keys with Radial.|
|/avatar/parameters/HeartBeatInt|Int|1 : QRS Interval (Temporarily set it to 1/5 of the RR interval) <br> 0 : Other times|
|/avatar/parameters/HeartBeatPulse|Bool|True : QRS Interval (Temporarily set it to 1/5 of the RR interval) <br> False : Other times|
|/avatar/parameters/HeartBeatToggle|Bool|Reverses with each heartbeat|

## After
|Addresss|Value Type|Description|
|-|-|-|
|/avatar/parameters/HeartRateInt|Int|Heart rate par min [0, 255]|
|/avatar/parameters/HeartRate3|Int|Same as HeartRateInt|
|/avatar/parameters/HeartRateFloat|Float|Normalized Heart rate ([0, 255] -> [-1, 1])|
|/avatar/parameters/HeartRate|Float|Same as HeartRateFloat|
|/avatar/parameters/HeartRateFloat01|Float|Normalized Heart rate ([0, 255] -> [0, 1]) <br> This is useful when controlling shape keys with Radial.|
|/avatar/parameters/HeartRate2|Float|Same as HeartRateFloat01|
|/avatar/parameters/HeartBeatInt|Int|1 : QRS Interval (Temporarily set it to 1/5 of the RR interval) <br> 0 : Other times|
|/avatar/parameters/HeartBeatPulse|Bool|True : QRS Interval (Temporarily set it to 1/5 of the RR interval) <br> False : Other times|
|/avatar/parameters/HeartBeatToggle|Bool|Reverses with each heartbeat|