### PR TITLE
Add auto connect setting

### DIFF
--- a/MiBand-Heartrate-2/App.config
+++ b/MiBand-Heartrate-2/App.config
@@ -3,10 +3,10 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
-	<appSettings>
-		<add key="useAutoConnect" value="false"/>
+    <appSettings>
+        <add key="useAutoConnect" value="false"/>
         <add key="autoConnectDeviceVersion" value="5"/>
         <add key="autoConnectDeviceName" value="Mi Smart Band 5"/>
         <add key="autoConnectDeviceAuthKey" value="0123456789abcdef0123456789abcdef"/>
-	</appSettings>
+    </appSettings>
 </configuration>

--- a/MiBand-Heartrate-2/App.config
+++ b/MiBand-Heartrate-2/App.config
@@ -3,4 +3,10 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
+	<appSettings>
+		<add key="useAutoConnect" value="false"/>
+        <add key="autoConnectDeviceVersion" value="5"/>
+        <add key="autoConnectDeviceName" value="Mi Smart Band 5"/>
+        <add key="autoConnectDeviceAuthKey" value="0123456789abcdef0123456789abcdef"/>
+	</appSettings>
 </configuration>

--- a/MiBand-Heartrate-2/MainWindow.xaml
+++ b/MiBand-Heartrate-2/MainWindow.xaml
@@ -25,11 +25,14 @@
             <Label Grid.Column="0" VerticalAlignment="Center" Content="{Binding StatusText}"></Label>
 
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Grid.Column="1">
-                <Button Content="Connect" Padding="10 5" Margin="5 5 0 5" Command="{Binding Command_Connect}">
+                <Button Content="Manual Connect" Padding="10 5" Margin="5 5 0 5" Command="{Binding Command_Connect}">
                     <Button.Style>
                         <Style TargetType="Button">
                             <Setter Property="Visibility" Value="Visible" />
                             <Style.Triggers>
+                                <DataTrigger Binding="{Binding UseAutoConnect}" Value="True">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                </DataTrigger>
                                 <DataTrigger Binding="{Binding IsConnected}" Value="True">
                                     <Setter Property="Visibility" Value="Collapsed" />
                                 </DataTrigger>
@@ -44,6 +47,21 @@
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding IsConnected}" Value="True">
                                     <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                </Button>
+                <Button Content="Auto Connect" Padding="10 5" Margin="5 5 0 5" Command="{Binding Command_Auto_Connect}">
+                    <Button.Style>
+                        <Style TargetType="Button">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding UseAutoConnect}" Value="True">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding IsConnected}" Value="True">
+                                    <Setter Property="Visibility" Value="Collapsed" />
                                 </DataTrigger>
                             </Style.Triggers>
                         </Style>

--- a/MiBand-Heartrate-2/MiBand-Heartrate-2.csproj
+++ b/MiBand-Heartrate-2/MiBand-Heartrate-2.csproj
@@ -42,6 +42,7 @@
       <HintPath>..\packages\Rug.Osc.1.2.5\lib\Rug.Osc.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.WindowsRuntime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">

--- a/README.ja.md
+++ b/README.ja.md
@@ -31,7 +31,7 @@ Windows10でMi Bandデバイスで心拍数を取得します。
 
 * `MiBand-Heartrate.exe`を起動してください
 
-* `Connect`ボタンを押してください
+* `Manual Connect`ボタンを押してください
 
 * `Select your device`から`Mi Band 2`や`Mi Band 3`を選択してください
 
@@ -49,7 +49,7 @@ Windows10でMi Bandデバイスで心拍数を取得します。
 
 * `MiBand-Heartrate.exe`を起動してください
 
-* `Connect`ボタンを押してください
+* `Manual Connect`ボタンを押してください
 
 * `Select your device`から`Mi Band 4`や`Mi Band 5`を選択してください
 
@@ -60,6 +60,36 @@ Windows10でMi Bandデバイスで心拍数を取得します。
 * 新しいウィンドウが出るので、そこに認証キーを入力して`Ok`を押してください
 
 * デバイスが正しく接続・認証されました、`Start`ボタンを押してください
+
+
+### 自動接続
+
+`MiBand-Heartrate-2.exe`と同じ階層にある`MiBand-Heartrate-2.exe.config`を設定することで自動接続をすることができるようになります。
+
+自動接続を有効にした場合、`Manual Connect`ボタンが`Auto Connect`ボタンに変わります。
+
+|キー|説明|備考|
+|-|-|-|
+|useAutoConnect|自動接続するかどうか|自動接続を有効にする場合は`true`|
+|autoConnectDeviceVersion|デバイスのバージョン|MiBand 4の場合は`4`、MiBand 5の場合は`5`|
+|autoConnectDeviceName|Bluetoothデバイスの名前|基本的にはMiBand 5の場合は`MiBand 5`|
+|autoConnectDeviceAuthkey|32文字の認証キー|例:`0123456789abcdef0123456789abcdef`|
+
+設定例
+``` xml
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+    </startup>
+    <appSettings>
+        <add key="useAutoConnect" value="true"/>
+        <add key="autoConnectDeviceVersion" value="5"/>
+        <add key="autoConnectDeviceName" value="Mi Smart Band 5"/>
+        <add key="autoConnectDeviceAuthKey" value="0123456789abcdef0123456789abcdef"/>
+    </appSettings>
+</configuration>
+```
 
 
 ### オプション

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Enable and monitor heartrate with Mi Band device on Windows 10.
 
 * Launch `MiBand-Heartrate.exe`
 
-* Click on `Connect` button and select your device from device list and set model on `Mi Band 2` or `Mi Band 3` then click on `Connect`
+* Click on `Manual Connect` button and select your device from device list and set model on `Mi Band 2` or `Mi Band 3` then click on `Connect`
 
 * Once your device is successfully connected and authenticated, click on `Start` button
 
@@ -44,11 +44,41 @@ Enable and monitor heartrate with Mi Band device on Windows 10.
 
 * Launch `MiBand-Heartrate.exe`
 
-* Click on `Connect` button and select your device from device list and set model on `Mi Band 4` then click on `Connect`
+* Click on `Manual Connect` button and select your device from device list and set model on `Mi Band 4` then click on `Connect`
 
 * A new window should appear, enter your authentication key then click on `Ok`
 
 * Once your device is successfully connected and authenticated, click on `Start` button
+
+
+### Automatic Connection
+
+You can make an automatic connection by setting `MiBand-Heartrate-2.exe.config` in the same directory as `MiBand-Heartrate-2.exe`.
+
+If you enable automatic connection, the `Manual Connect` button changes to a `Auto Connect` button.
+
+|Key|Description|Note|
+|-|-|-|
+|useAutoConnect|Whether to connect automatically|`true` to enable automatic connection|
+|autoConnectDeviceVersion|Device version|`4` for Mi Band 4,`5` for Mi Band 5|
+|autoConnectDeviceName|Bluetooth device name|Basically `MiBand 5` for Mi Band 5|
+|autoConnectDeviceAuthkey|32-characters authentication key|Example: `0123456789abcdef0123456789abcdef`|
+
+Example
+``` xml
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+    </startup>
+    <appSettings>
+        <add key="useAutoConnect" value="true"/>
+        <add key="autoConnectDeviceVersion" value="5"/>
+        <add key="autoConnectDeviceName" value="Mi Smart Band 5"/>
+        <add key="autoConnectDeviceAuthKey" value="0123456789abcdef0123456789abcdef"/>
+    </appSettings>
+</configuration>
+```
 
 
 ### Options


### PR DESCRIPTION
## Automatic Connection

You can make an automatic connection by setting `MiBand-Heartrate-2.exe.config` in the same directory as `MiBand-Heartrate-2.exe`.

If you enable automatic connection, the `Manual Connect` button changes to a `Auto Connect` button.

|Key|Description|Note|
|-|-|-|
|useAutoConnect|Whether to connect automatically|`true` to enable automatic connection|
|autoConnectDeviceVersion|Device version|`4` for Mi Band 4,`5` for Mi Band 5|
|autoConnectDeviceName|Bluetooth device name|Basically `MiBand 5` for Mi Band 5|
|autoConnectDeviceAuthkey|32-characters authentication key|Example: `0123456789abcdef0123456789abcdef`|

Example
``` xml
<?xml version="1.0" encoding="utf-8" ?>
<configuration>
    <startup> 
        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
    </startup>
    <appSettings>
        <add key="useAutoConnect" value="true"/>
        <add key="autoConnectDeviceVersion" value="5"/>
        <add key="autoConnectDeviceName" value="Mi Smart Band 5"/>
        <add key="autoConnectDeviceAuthKey" value="0123456789abcdef0123456789abcdef"/>
    </appSettings>
</configuration>
```