### PR TITLE
remove white main window background

### DIFF
--- a/MiBand-Heartrate-2/AuthenticationKeyWindow.xaml
+++ b/MiBand-Heartrate-2/AuthenticationKeyWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="MiBand_Heartrate_2.AuthenticationKeyWindow"
+<Window x:Class="MiBand_Heartrate_2.AuthenticationKeyWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -15,7 +15,7 @@
         <local:AuthenticationKeyViewModel></local:AuthenticationKeyViewModel>
     </Window.DataContext>
 
-    <StackPanel Background="White" Margin="10">
+    <StackPanel Margin="10">
         <StackPanel Orientation="Horizontal">
             <Label Content="Enter your auth. key" Width="150"></Label>
             <TextBox Width="240" Text="{Binding Key, Mode=TwoWay}" VerticalContentAlignment="Center"></TextBox>

--- a/MiBand-Heartrate-2/ConnectionWindow.xaml
+++ b/MiBand-Heartrate-2/ConnectionWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="MiBand_Heartrate_2.ConnectionWindow"
+<Window x:Class="MiBand_Heartrate_2.ConnectionWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -17,7 +17,7 @@
         <local:ConnectionWindowViewModel></local:ConnectionWindowViewModel>
     </Window.DataContext>
 
-    <StackPanel Background="White" Margin="10">
+    <StackPanel Margin="10">
         <StackPanel Orientation="Horizontal">
             <Label Content="Select your device" Width="150"></Label>
             <ComboBox Width="200" SelectedValue="{Binding SelectedDevice, Mode=TwoWay}" ItemsSource="{Binding Devices}" DisplayMemberPath="Name"></ComboBox>

--- a/MiBand-Heartrate-2/MainWindow.xaml
+++ b/MiBand-Heartrate-2/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="MiBand_Heartrate_2.MainWindow"
+<Window x:Class="MiBand_Heartrate_2.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -15,7 +15,7 @@
         <local:MainWindowViewModel></local:MainWindowViewModel>
     </Window.DataContext>
     
-    <StackPanel Background="White">
+    <StackPanel>
         <Grid Margin="5" VerticalAlignment="Top">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition></ColumnDefinition>

--- a/MiBand-Heartrate-2/MainWindow.xaml
+++ b/MiBand-Heartrate-2/MainWindow.xaml
@@ -70,14 +70,14 @@
             </StackPanel>
         </Grid>
 
-        <GroupBox Header="Heartrate" Margin="5" BorderBrush="DarkGray">
+        <GroupBox Header="Heartrate" Margin="5" >
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                 <Label FontSize="32" Margin="0 10" Content="{Binding Device.Heartrate}"></Label>
                 <Label FontSize="32" Margin="0 10">bpm</Label>
             </StackPanel>
         </GroupBox>
 
-        <GroupBox Header="Options" Margin="5" BorderBrush="DarkGray">
+        <GroupBox Header="Options" Margin="5">
             <StackPanel Margin="5">
                 <CheckBox Margin="0 2" IsChecked="{Binding ContinuousMode, Mode=TwoWay}">Enable continuous mode</CheckBox>
                 <CheckBox Margin="0 2" IsChecked="{Binding EnableCSVOutput, Mode=TwoWay}">Export data in CSV file</CheckBox>


### PR DESCRIPTION
custom windows themes may use different colors for background and text, the hard coded white background made things look weird and out of place:
before:
![image](https://github.com/mkc1370/miband-heartrate-osc/assets/31988415/13f00337-7a6d-444f-8002-8a71253487d6)

after:
![image](https://github.com/mkc1370/miband-heartrate-osc/assets/31988415/91bb16b0-65ac-44e0-b7a2-25971246e240)
